### PR TITLE
Fix to luna.nimble, name is not a valid key.

### DIFF
--- a/luna.nimble
+++ b/luna.nimble
@@ -1,6 +1,5 @@
 # Package
 
-name          = "luna"
 version       = "0.1.0"
 author        = "Jackson Broussard"
 description   = "Lua convenience library for nim"


### PR DESCRIPTION
`nimble check`

```
       Tip: 4 messages have been suppressed, use --verbose to show them.
     Error: Could not validate package:
        ... Could not read package info file in /p/nimwatch/pkgs/luna/luna.nimble;
        ...   Reading as ini file failed with: 
        ...     Invalid section: .
        ...   Evaluating as NimScript file failed with: 
        ...     p/nimwatch/pkgs/luna/luna.nimble(3, 1) Error: undeclared identifier: 'name'.
```